### PR TITLE
feat: linear read time

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,8 @@ fn main() -> std::io::Result<()> {
     let mut current_size = 0usize;
     let mut start_time = Instant::now(); // Start the timer
 
+    let mut tot_lines = 0;
+
     while current_size < target_size {
         let line_length = rng.sample(&length_range);
         let line: String = (0..line_length)
@@ -39,11 +41,12 @@ fn main() -> std::io::Result<()> {
         file.write_all(line.as_bytes())?;
         file.write_all(b"\n")?;
         current_size += line.len() + 1; // +1 for the newline character
+        tot_lines += 1;
     }
 
     file.flush()?;
 
-    println!("Generated file {}", path.display());
+    println!("Generated file {} with {} lines", path.display(), tot_lines);
     println!("Time to write file: {:?}", start_time.elapsed()); // Print the duration
 
     /////////////////////////////////
@@ -52,7 +55,7 @@ fn main() -> std::io::Result<()> {
     start_time = Instant::now();
     let file = File::open(&path)?;
     let reader = BufReader::new(file);
-    let nth_line = 1000;
+    let nth_line = 10000000;
 
     let line = reader
         .lines()
@@ -60,8 +63,8 @@ fn main() -> std::io::Result<()> {
         .transpose()? // Turn Option<Result<String>> into Result<Option<String>>
         .unwrap_or_else(|| "Line not found".to_string());
 
-    println!("The 1000th line is: {}", line);
-    println!("Time to read 1000th line: {:?}", start_time.elapsed()); // Print the duration
+    println!("The 10 millionth line is: {}", line);
+    println!("Time to read 10 millionth line: {:?}", start_time.elapsed()); // Print the duration
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use rand::{distributions::Uniform, Rng};
 use std::env;
 use std::fs::File;
-use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::io::{self, BufRead, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -38,7 +38,9 @@ fn main() -> std::io::Result<()> {
             .map(char::from)
             .collect();
 
+        file.write_all(format!("{}: ", tot_lines).as_bytes())?;
         file.write_all(line.as_bytes())?;
+
         file.write_all(b"\n")?;
         current_size += line.len() + 1; // +1 for the newline character
         tot_lines += 1;
@@ -49,14 +51,15 @@ fn main() -> std::io::Result<()> {
     println!("Generated file {} with {} lines", path.display(), tot_lines);
     println!("Time to write file: {:?}", start_time.elapsed()); // Print the duration
 
-    /////////////////////////////////
-    // Read nth line from the file //
-    /////////////////////////////////
-    start_time = Instant::now();
+    ///////////////////////////////////////////////////////
+    // Read nth line from the file using Lines -> > 1 sec//
+    ///////////////////////////////////////////////////////
+
     let file = File::open(&path)?;
     let reader = BufReader::new(file);
     let nth_line = 10000000;
 
+    start_time = Instant::now();
     let line = reader
         .lines()
         .nth(nth_line - 1) // nth is zero-based, so subtract 1
@@ -65,6 +68,32 @@ fn main() -> std::io::Result<()> {
 
     println!("The 10 millionth line is: {}", line);
     println!("Time to read 10 millionth line: {:?}", start_time.elapsed()); // Print the duration
+
+    //////////////////////////////////////////////////////
+    // Seek directly to nth byte and read line -> < 1ms //
+    //////////////////////////////////////////////////////
+
+    let file_with_seek = File::open(&path)?;
+    let mut reader_with_seek = BufReader::new(file_with_seek);
+
+    // Seek to the 2 billionth byte of the file
+    let start_time = Instant::now();
+    reader_with_seek.seek(SeekFrom::Start(2_000_000_000))?;
+
+    // Read the next 250 characters
+    let mut buffer = vec![0; 250]; // Buffer to hold bytes
+    reader_with_seek.read_exact(&mut buffer)?;
+
+    // Convert buffer to string
+    let result_string =
+        String::from_utf8(buffer).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    println!("The ~10 millionth line via seek: {}", result_string);
+
+    println!(
+        "Time taken to seek to ~10 millionth line via seek: {:?}",
+        start_time.elapsed()
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Issue

Simply using `std::io::BufRead` with `nth()` is very slow:
- 1.5ms for 10 thousandth line
- 1,500ms for 10 millionth line

The actual code is:

```
let file = File::open(&path)?;
let reader = BufRead::new(file);
let nth_line = 10000000;

let line = reader
  .lines()
  .nth(nth_line - 1)
```

The core of the issue is `nth()`, which is a dumb function that just iterates over each line until it hits the nth element. This is very slow since the buffer reader just loads every single byte from the file until it hits the specific line, not using the benefits of `BufRead` at all. 

## PoC

This branch tests the `Seek:seek()` function to instantly jump to a specific byte offset of the file and shows promising results -> 12 millionth line in 0.006ms 🤣 

<img width="464" alt="image" src="https://github.com/joshpwrk/loupe/assets/46257136/a787cdcb-d709-41f7-a2dd-0016a64f6744">

The image above shows two lines because in the PoC I don't know the byte offset of each line, so I just print 250 bytes at the 2 billionth byte offset (around where I expect the 10 millionth line to be). In the above example, two lines are shown that fit into this bucket. 

When counting the full file opening and buffer creation it still only takes 0.05ms. 

See below for polished solution. 

## Possible Solution

1. Use `ReadBuf::Seek::seek()` as shown above to skip directly to the line we want.
2. To make this exact (unlike PoC), we may store some `metadata` of the current file that holds the "start" and "end" byte for each 1000 line chunk, where:

- 0-999: 0...13123 bytes
- 1000-1999: 13124...22232 bytes
- ...

The size of this metadata should be on average 1000x smaller than the source file, making it relatively lean.

3. There should be a parallel thread running constantly appending to this metadata as the file is expected to grow.  